### PR TITLE
Feat: UNT-T27821 Create Coloured Neumorphic views demo screen

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,44 +7,44 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0B2C19A3379884D2D9A099F0BF24F7E6 /* NMButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D22578BBDF5C5861275948368F92262 /* NMButtonStyle.swift */; };
-		2CF7B5AFE491C3360E79A4ED4B67E676 /* InnerShadowModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31336CFCED337CFC0A5B02A0B5022140 /* InnerShadowModifier.swift */; };
-		3AAF0ED277F0F86ABFD13EE2A596C67F /* SSNeumorphicView-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 50E0B088DD799AEBFF09187971C36EED /* SSNeumorphicView-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3BD45C003CA46C86DC6F7249234C2A45 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D245E0514AAC1A2B9A6D5EA2F383E90F /* UIKit.framework */; };
+		03B0D7787101E0C8512AB8577DB063FB /* Color+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782E926343239DFBBA9EAC0D6449A30B /* Color+Extension.swift */; };
+		20635F9AF81DE420B3CC109BC4DE13B5 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D245E0514AAC1A2B9A6D5EA2F383E90F /* UIKit.framework */; };
+		218C79B2F2245C5838FA75AC5B0A2BF2 /* ColorSchemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608690826CD793A1CAC8301B35E39502 /* ColorSchemeManager.swift */; };
+		21D29DC737DF1191595717C25FB3DF23 /* OuterShadowModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = F051E816C305F18D624737D100AF0E03 /* OuterShadowModifier.swift */; };
+		4043948E4ED5CB7B912654301993EA0F /* SSNeumorphicTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6949A6992E9D44EE89C0FCF72AEAF02 /* SSNeumorphicTextField.swift */; };
+		4354D29B42974BAB677A32411A289C38 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EAB6F611E86A4758835A715E4B4184F6 /* Foundation.framework */; };
 		55855AFD2842EC3481B0B9EF194DF9DF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EAB6F611E86A4758835A715E4B4184F6 /* Foundation.framework */; };
+		57B678D261608678F9619E2D09BFB615 /* SSNeumorphicLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A577CA36CAD75878EE8BFF3BE745F9B /* SSNeumorphicLayer.swift */; };
 		594F470540C06A083A12FEC7BDF5C0A4 /* Pods-SSNeumorphicView_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D2094757ADEE660C8815F229502F445C /* Pods-SSNeumorphicView_Tests-dummy.m */; };
+		59533624A21B64CDA632B66A0B2F315E /* InnerShadowModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF7C742F9D24DED7BD861293DA1FBE9C /* InnerShadowModifier.swift */; };
 		5C078D3D50DAC6308EBE1A7235500C13 /* Pods-SSNeumorphicView_Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = BCCD7BA18CCF94BBC29027F810C6090A /* Pods-SSNeumorphicView_Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5EC46E1FA057B68B10046755E87F5F16 /* SSNeumorphicView-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BE0B9F62CA464BCD20FDCA63505525F /* SSNeumorphicView-dummy.m */; };
-		7E7BDF536D8B9E8ED247DF70D4B71200 /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBBDB2DD917282B3608444C225A6740F /* View+Extension.swift */; };
-		8C3DCA358F92C275BCBFD135B4BEAFF2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EAB6F611E86A4758835A715E4B4184F6 /* Foundation.framework */; };
-		9569A470047F490F80D424FFC5AE25C0 /* NMToggleStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6503A361A1585F27FDA2C1C5D9156B5 /* NMToggleStyle.swift */; };
+		6EB3D0FA230B888A312D955DF1A8983E /* SSNeumorphicView-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BE0B9F62CA464BCD20FDCA63505525F /* SSNeumorphicView-dummy.m */; };
+		8F8F0BA818BD9EFBB58C1E771B519B0D /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A672AFC9FEDF6F67B73AF6D7E6F7A12A /* View+Extension.swift */; };
+		97EAF528B73D1D65509641E11A64DAE8 /* NMToggleStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D15ABD8E89F71592C3D17E8FB9A59475 /* NMToggleStyle.swift */; };
+		A137862B3202F612FFBDB1F3E8088589 /* SSNeumorphicView-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 50E0B088DD799AEBFF09187971C36EED /* SSNeumorphicView-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A1A9054148E9AEBA5651FA127ACFE6CF /* Pods-SSNeumorphicView_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 80A07B8CB35C800B06322559CB07ED13 /* Pods-SSNeumorphicView_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B067D48A9C9287D6FA4491D37B70FC0D /* SSNeumorphicButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ADB77B55F8972F0E3ACFB53349ED210 /* SSNeumorphicButton.swift */; };
-		BC3E7B67249127B70FC229ECA50C0B69 /* SSNeumorphicTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6949A6992E9D44EE89C0FCF72AEAF02 /* SSNeumorphicTextField.swift */; };
+		AEFC372DE44B681C7351516806431E56 /* SSNeumorphicView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F11768CB88AA7A924F658FC957E4C8 /* SSNeumorphicView.swift */; };
+		B70903068440C89B3FB10BA61A877B18 /* LinearGradient+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED742EBD680D1796303245AE82B91A07 /* LinearGradient+Extension.swift */; };
+		B888011D97B2A573C872D4E59454F2B8 /* NMButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A53D3894F16B4815B5DA9BBDDB7219DE /* NMButtonStyle.swift */; };
 		BE9FB8BF61AF4795FD889AE7A77E01F8 /* Pods-SSNeumorphicView_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 157AC2F3BBD8C23671708851A50E3971 /* Pods-SSNeumorphicView_Example-dummy.m */; };
-		C60864538DA6B5F029FD52D0ABFCF13E /* OuterShadowModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FDE4AFEA3B184BC8344D0C27EF23F28 /* OuterShadowModifier.swift */; };
-		D073A03D55629767322CAF47B42D4C75 /* LinearGradient+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ECD4DCC7CA0B3C5D8BE0692C3D8395F /* LinearGradient+Extension.swift */; };
 		D6C9156683395502804A6D0C29992DBA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EAB6F611E86A4758835A715E4B4184F6 /* Foundation.framework */; };
-		E60817F9A0E732EA6BFF6648AD178997 /* ColorSchemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AD12DE86AC7186A503E819F980E5DE /* ColorSchemeManager.swift */; };
-		F18FE16D9971A853F0A6F5236DA4A293 /* SSNeumorphicLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A577CA36CAD75878EE8BFF3BE745F9B /* SSNeumorphicLayer.swift */; };
-		FC86F3D29C505EDC58E3F0447C776F9E /* Color+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934926B74578BE3FC6DEE8C94852BE2E /* Color+Extension.swift */; };
-		FFADDD648E1CF9D133F1B91F4984D96D /* SSNeumorphicView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F11768CB88AA7A924F658FC957E4C8 /* SSNeumorphicView.swift */; };
+		F4D665B02CFAC4FEC765FC980756BE5F /* SSNeumorphicButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ADB77B55F8972F0E3ACFB53349ED210 /* SSNeumorphicButton.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		25A812372BB05B66F202F33B64EA1C1F /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 9A4BF4BE08D3D15C28A262F12B1415B3;
-			remoteInfo = "Pods-SSNeumorphicView_Example";
-		};
-		392CEA713654F90366DB9B3F916E46C8 /* PBXContainerItemProxy */ = {
+		47CBBF93FC79A79E2F791EA5F32E4B4F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = DAAB6534CA573FAE41802F72CCE1277E;
 			remoteInfo = SSNeumorphicView;
+		};
+		6D8F836AE703BDCB6D05E357C3BA4439 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9A4BF4BE08D3D15C28A262F12B1415B3;
+			remoteInfo = "Pods-SSNeumorphicView_Example";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -52,12 +52,9 @@
 		04FCCDDC14C328C94193A2C5C94C19E4 /* Pods-SSNeumorphicView_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-SSNeumorphicView_Example-frameworks.sh"; sourceTree = "<group>"; };
 		05D3534F55340FB0DD30C42C6E98EF04 /* SSNeumorphicView-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "SSNeumorphicView-Info.plist"; sourceTree = "<group>"; };
 		0A577CA36CAD75878EE8BFF3BE745F9B /* SSNeumorphicLayer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SSNeumorphicLayer.swift; path = Sources/SSNeumorphicView/Classes/SSNeumorphicLayer.swift; sourceTree = "<group>"; };
-		0D22578BBDF5C5861275948368F92262 /* NMButtonStyle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NMButtonStyle.swift; sourceTree = "<group>"; };
 		14C25FFE94099F1A00644E0831536B0E /* Pods-SSNeumorphicView_Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SSNeumorphicView_Tests-acknowledgements.plist"; sourceTree = "<group>"; };
 		157AC2F3BBD8C23671708851A50E3971 /* Pods-SSNeumorphicView_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-SSNeumorphicView_Example-dummy.m"; sourceTree = "<group>"; };
 		19CFA757915C91EB9DF898DFA77DDC86 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
-		31336CFCED337CFC0A5B02A0B5022140 /* InnerShadowModifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InnerShadowModifier.swift; sourceTree = "<group>"; };
-		3ECD4DCC7CA0B3C5D8BE0692C3D8395F /* LinearGradient+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LinearGradient+Extension.swift"; sourceTree = "<group>"; };
 		430511E930ABBBAD1B0E6998EA25F727 /* Pods_SSNeumorphicView_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SSNeumorphicView_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4A255F6828E16682314233C4D8882693 /* SSNeumorphicView-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SSNeumorphicView-prefix.pch"; sourceTree = "<group>"; };
 		4BC2D963CCC83A6C49E317CF4DCBEE4A /* Pods-SSNeumorphicView_Tests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SSNeumorphicView_Tests-Info.plist"; sourceTree = "<group>"; };
@@ -65,18 +62,20 @@
 		50E0B088DD799AEBFF09187971C36EED /* SSNeumorphicView-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SSNeumorphicView-umbrella.h"; sourceTree = "<group>"; };
 		53B2EA2015B38D172BE9499B506130D9 /* SSNeumorphicView.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = SSNeumorphicView.modulemap; sourceTree = "<group>"; };
 		5BACC9CA86901A2B326884A0BB0BC9CB /* Pods_SSNeumorphicView_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SSNeumorphicView_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		608690826CD793A1CAC8301B35E39502 /* ColorSchemeManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ColorSchemeManager.swift; sourceTree = "<group>"; };
 		612AA768AA1A00EAD36C0915E52D6D8B /* Pods-SSNeumorphicView_Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-SSNeumorphicView_Tests.modulemap"; sourceTree = "<group>"; };
 		63F44A008894F053192326ECE5DB9652 /* Pods-SSNeumorphicView_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SSNeumorphicView_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		694E50A67AE4FFB5D0012136D762D364 /* Pods-SSNeumorphicView_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-SSNeumorphicView_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
 		6BE0B9F62CA464BCD20FDCA63505525F /* SSNeumorphicView-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SSNeumorphicView-dummy.m"; sourceTree = "<group>"; };
+		782E926343239DFBBA9EAC0D6449A30B /* Color+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Color+Extension.swift"; sourceTree = "<group>"; };
 		7ADB77B55F8972F0E3ACFB53349ED210 /* SSNeumorphicButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SSNeumorphicButton.swift; path = Sources/SSNeumorphicView/Classes/SSNeumorphicButton.swift; sourceTree = "<group>"; };
 		7C73668DD75EA4DA395E8B3F98DA90CC /* SSNeumorphicView.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SSNeumorphicView.debug.xcconfig; sourceTree = "<group>"; };
 		7E6DFA34C51AACF31FBF327E9F25901A /* SSNeumorphicView.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SSNeumorphicView.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		7FDE4AFEA3B184BC8344D0C27EF23F28 /* OuterShadowModifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OuterShadowModifier.swift; sourceTree = "<group>"; };
 		80A07B8CB35C800B06322559CB07ED13 /* Pods-SSNeumorphicView_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SSNeumorphicView_Example-umbrella.h"; sourceTree = "<group>"; };
-		934926B74578BE3FC6DEE8C94852BE2E /* Color+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Color+Extension.swift"; sourceTree = "<group>"; };
 		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		A47BEFA312A5C8EAD069221264166B43 /* Pods-SSNeumorphicView_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-SSNeumorphicView_Example.modulemap"; sourceTree = "<group>"; };
+		A53D3894F16B4815B5DA9BBDDB7219DE /* NMButtonStyle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NMButtonStyle.swift; sourceTree = "<group>"; };
+		A672AFC9FEDF6F67B73AF6D7E6F7A12A /* View+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
 		A6949A6992E9D44EE89C0FCF72AEAF02 /* SSNeumorphicTextField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SSNeumorphicTextField.swift; path = Sources/SSNeumorphicView/Classes/SSNeumorphicTextField.swift; sourceTree = "<group>"; };
 		AA4A456DDCAFB2AB5612B4BCDDF97778 /* Pods-SSNeumorphicView_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SSNeumorphicView_Example-acknowledgements.plist"; sourceTree = "<group>"; };
 		AA7D0FB1B1EB0010CCC4A742CE68CE47 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
@@ -84,15 +83,16 @@
 		C0F11768CB88AA7A924F658FC957E4C8 /* SSNeumorphicView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SSNeumorphicView.swift; path = Sources/SSNeumorphicView/Classes/SSNeumorphicView.swift; sourceTree = "<group>"; };
 		C244FFA6C1EF07C48A34B2B416CBBB1C /* Pods-SSNeumorphicView_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SSNeumorphicView_Example.release.xcconfig"; sourceTree = "<group>"; };
 		C34395C4BA1E538CC9E37D5D5E1083A3 /* Pods-SSNeumorphicView_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SSNeumorphicView_Example.debug.xcconfig"; sourceTree = "<group>"; };
-		C3AD12DE86AC7186A503E819F980E5DE /* ColorSchemeManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ColorSchemeManager.swift; sourceTree = "<group>"; };
+		D15ABD8E89F71592C3D17E8FB9A59475 /* NMToggleStyle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NMToggleStyle.swift; sourceTree = "<group>"; };
 		D2094757ADEE660C8815F229502F445C /* Pods-SSNeumorphicView_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-SSNeumorphicView_Tests-dummy.m"; sourceTree = "<group>"; };
 		D245E0514AAC1A2B9A6D5EA2F383E90F /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		DF26FDD89A1E0C7FD3B8490184737E28 /* Pods-SSNeumorphicView_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SSNeumorphicView_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		DF37CFFF3D237F48F89953E68DCC13E5 /* SSNeumorphicView.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SSNeumorphicView.release.xcconfig; sourceTree = "<group>"; };
+		DF7C742F9D24DED7BD861293DA1FBE9C /* InnerShadowModifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InnerShadowModifier.swift; sourceTree = "<group>"; };
 		EAB6F611E86A4758835A715E4B4184F6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		EBBDB2DD917282B3608444C225A6740F /* View+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
+		ED742EBD680D1796303245AE82B91A07 /* LinearGradient+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LinearGradient+Extension.swift"; sourceTree = "<group>"; };
+		F051E816C305F18D624737D100AF0E03 /* OuterShadowModifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OuterShadowModifier.swift; sourceTree = "<group>"; };
 		F11F3324F739D1112CF81BC9AA4C9C2E /* SSNeumorphicView.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; path = SSNeumorphicView.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		F6503A361A1585F27FDA2C1C5D9156B5 /* NMToggleStyle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NMToggleStyle.swift; sourceTree = "<group>"; };
 		FA1A743BD58589BF9056C94C775B9194 /* Pods-SSNeumorphicView_Example-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SSNeumorphicView_Example-Info.plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -113,36 +113,18 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		DCE8F2F4EF030BC7E7273F6CD719F9CC /* Frameworks */ = {
+		D50E90B45F5E9D811255A8BB722E4084 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8C3DCA358F92C275BCBFD135B4BEAFF2 /* Foundation.framework in Frameworks */,
-				3BD45C003CA46C86DC6F7249234C2A45 /* UIKit.framework in Frameworks */,
+				4354D29B42974BAB677A32411A289C38 /* Foundation.framework in Frameworks */,
+				20635F9AF81DE420B3CC109BC4DE13B5 /* UIKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		0B2B640DA1625010E3F54A2C5D6B04C9 /* Modifiers */ = {
-			isa = PBXGroup;
-			children = (
-				31336CFCED337CFC0A5B02A0B5022140 /* InnerShadowModifier.swift */,
-				7FDE4AFEA3B184BC8344D0C27EF23F28 /* OuterShadowModifier.swift */,
-			);
-			path = Modifiers;
-			sourceTree = "<group>";
-		};
-		0D0346FF094A4591F8FD119ABE218044 /* Styles */ = {
-			isa = PBXGroup;
-			children = (
-				0D22578BBDF5C5861275948368F92262 /* NMButtonStyle.swift */,
-				F6503A361A1585F27FDA2C1C5D9156B5 /* NMToggleStyle.swift */,
-			);
-			path = Styles;
-			sourceTree = "<group>";
-		};
 		1628BF05B4CAFDCC3549A101F5A10A17 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -151,16 +133,13 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		34E7A7DD706EA3B2776790C40C961AB8 /* SwiftUI */ = {
+		24D87F1877AAE8C55E90837201A5152F /* Modifiers */ = {
 			isa = PBXGroup;
 			children = (
-				C3AD12DE86AC7186A503E819F980E5DE /* ColorSchemeManager.swift */,
-				C3273AE0C3E4F235E5C61A9F72E478C6 /* Helpers */,
-				0B2B640DA1625010E3F54A2C5D6B04C9 /* Modifiers */,
-				0D0346FF094A4591F8FD119ABE218044 /* Styles */,
+				DF7C742F9D24DED7BD861293DA1FBE9C /* InnerShadowModifier.swift */,
+				F051E816C305F18D624737D100AF0E03 /* OuterShadowModifier.swift */,
 			);
-			name = SwiftUI;
-			path = Sources/SSNeumorphicView/Classes/SwiftUI;
+			path = Modifiers;
 			sourceTree = "<group>";
 		};
 		480BB6C0AEC3D73B67EBF39C8D9FAA8C /* Pods-SSNeumorphicView_Tests */ = {
@@ -207,10 +186,18 @@
 				C0F11768CB88AA7A924F658FC957E4C8 /* SSNeumorphicView.swift */,
 				58ABDC57AF60E218D3FD7632DA0D6847 /* Pod */,
 				E834C7DDE39869E7B1E38311988EDF4E /* Support Files */,
-				34E7A7DD706EA3B2776790C40C961AB8 /* SwiftUI */,
+				B77DBD7C2ECBE801597CEDFEF26D27BB /* SwiftUI */,
 			);
 			name = SSNeumorphicView;
 			path = ../..;
+			sourceTree = "<group>";
+		};
+		85B7074AE8158DC97AF008F98386726D /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				933C473F0FD42DAD30CEAC350EC8A3B4 /* Extensions */,
+			);
+			path = Helpers;
 			sourceTree = "<group>";
 		};
 		8DED546EF27E90FC30DEF861C628E6D9 /* Pods-SSNeumorphicView_Example */ = {
@@ -228,6 +215,28 @@
 			);
 			name = "Pods-SSNeumorphicView_Example";
 			path = "Target Support Files/Pods-SSNeumorphicView_Example";
+			sourceTree = "<group>";
+		};
+		933C473F0FD42DAD30CEAC350EC8A3B4 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				782E926343239DFBBA9EAC0D6449A30B /* Color+Extension.swift */,
+				ED742EBD680D1796303245AE82B91A07 /* LinearGradient+Extension.swift */,
+				A672AFC9FEDF6F67B73AF6D7E6F7A12A /* View+Extension.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		B77DBD7C2ECBE801597CEDFEF26D27BB /* SwiftUI */ = {
+			isa = PBXGroup;
+			children = (
+				608690826CD793A1CAC8301B35E39502 /* ColorSchemeManager.swift */,
+				85B7074AE8158DC97AF008F98386726D /* Helpers */,
+				24D87F1877AAE8C55E90837201A5152F /* Modifiers */,
+				CC50E457B21E6D12AE1BC92E99283E7F /* Styles */,
+			);
+			name = SwiftUI;
+			path = Sources/SSNeumorphicView/Classes/SwiftUI;
 			sourceTree = "<group>";
 		};
 		B9EB5D8C6E8C29655A70AA76B467C1CA /* Targets Support Files */ = {
@@ -249,22 +258,13 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		BE865C99EAAA9B44F4E3B36C7C8AFF80 /* Extensions */ = {
+		CC50E457B21E6D12AE1BC92E99283E7F /* Styles */ = {
 			isa = PBXGroup;
 			children = (
-				934926B74578BE3FC6DEE8C94852BE2E /* Color+Extension.swift */,
-				3ECD4DCC7CA0B3C5D8BE0692C3D8395F /* LinearGradient+Extension.swift */,
-				EBBDB2DD917282B3608444C225A6740F /* View+Extension.swift */,
+				A53D3894F16B4815B5DA9BBDDB7219DE /* NMButtonStyle.swift */,
+				D15ABD8E89F71592C3D17E8FB9A59475 /* NMToggleStyle.swift */,
 			);
-			path = Extensions;
-			sourceTree = "<group>";
-		};
-		C3273AE0C3E4F235E5C61A9F72E478C6 /* Helpers */ = {
-			isa = PBXGroup;
-			children = (
-				BE865C99EAAA9B44F4E3B36C7C8AFF80 /* Extensions */,
-			);
-			path = Helpers;
+			path = Styles;
 			sourceTree = "<group>";
 		};
 		CF1408CF629C7361332E53B88F7BD30C = {
@@ -312,19 +312,19 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		60882EDE3E7080E18FD1F58DBFFD0CF3 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				3AAF0ED277F0F86ABFD13EE2A596C67F /* SSNeumorphicView-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		CDC0D7856B35A128AE134651FC7DAB32 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				5C078D3D50DAC6308EBE1A7235500C13 /* Pods-SSNeumorphicView_Tests-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E9FDD1BCC5FF408932E83657BF9D9CC1 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A137862B3202F612FFBDB1F3E8088589 /* SSNeumorphicView-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -343,7 +343,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				E6FB695242191C2F34EB1BFE3F0EC653 /* PBXTargetDependency */,
+				150A51EBC69BB7E7F03737A955BCF7F0 /* PBXTargetDependency */,
 			);
 			name = "Pods-SSNeumorphicView_Tests";
 			productName = Pods_SSNeumorphicView_Tests;
@@ -362,7 +362,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				0F77C200AD321FC4B940A9BC1867C99F /* PBXTargetDependency */,
+				4E8B539F1C56EA5C2F2FE3DC702CFEC6 /* PBXTargetDependency */,
 			);
 			name = "Pods-SSNeumorphicView_Example";
 			productName = Pods_SSNeumorphicView_Example;
@@ -371,12 +371,12 @@
 		};
 		DAAB6534CA573FAE41802F72CCE1277E /* SSNeumorphicView */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = A6BE21B9D9F9993D1DE0BBF70C879F20 /* Build configuration list for PBXNativeTarget "SSNeumorphicView" */;
+			buildConfigurationList = 400C8C38773D22E7471520C199DD66B5 /* Build configuration list for PBXNativeTarget "SSNeumorphicView" */;
 			buildPhases = (
-				60882EDE3E7080E18FD1F58DBFFD0CF3 /* Headers */,
-				5F581C251FB71B5F3148D87241AC406D /* Sources */,
-				DCE8F2F4EF030BC7E7273F6CD719F9CC /* Frameworks */,
-				D035769C79859BA055D1D34D4A3005EA /* Resources */,
+				E9FDD1BCC5FF408932E83657BF9D9CC1 /* Headers */,
+				DCE9024FD390E5892697B0EE0807521B /* Sources */,
+				D50E90B45F5E9D811255A8BB722E4084 /* Frameworks */,
+				139E43009FCFE66D9E444EBC27DA0F58 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -424,14 +424,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		C8DE41A24ED95A06B12F8F252A622C60 /* Resources */ = {
+		139E43009FCFE66D9E444EBC27DA0F58 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D035769C79859BA055D1D34D4A3005EA /* Resources */ = {
+		C8DE41A24ED95A06B12F8F252A622C60 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -449,23 +449,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		5F581C251FB71B5F3148D87241AC406D /* Sources */ = {
+		DCE9024FD390E5892697B0EE0807521B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FC86F3D29C505EDC58E3F0447C776F9E /* Color+Extension.swift in Sources */,
-				E60817F9A0E732EA6BFF6648AD178997 /* ColorSchemeManager.swift in Sources */,
-				2CF7B5AFE491C3360E79A4ED4B67E676 /* InnerShadowModifier.swift in Sources */,
-				D073A03D55629767322CAF47B42D4C75 /* LinearGradient+Extension.swift in Sources */,
-				0B2C19A3379884D2D9A099F0BF24F7E6 /* NMButtonStyle.swift in Sources */,
-				C60864538DA6B5F029FD52D0ABFCF13E /* OuterShadowModifier.swift in Sources */,
-				B067D48A9C9287D6FA4491D37B70FC0D /* SSNeumorphicButton.swift in Sources */,
-				F18FE16D9971A853F0A6F5236DA4A293 /* SSNeumorphicLayer.swift in Sources */,
-				BC3E7B67249127B70FC229ECA50C0B69 /* SSNeumorphicTextField.swift in Sources */,
-				FFADDD648E1CF9D133F1B91F4984D96D /* SSNeumorphicView.swift in Sources */,
-				5EC46E1FA057B68B10046755E87F5F16 /* SSNeumorphicView-dummy.m in Sources */,
-				9569A470047F490F80D424FFC5AE25C0 /* NMToggleStyle.swift in Sources */,
-				7E7BDF536D8B9E8ED247DF70D4B71200 /* View+Extension.swift in Sources */,
+				03B0D7787101E0C8512AB8577DB063FB /* Color+Extension.swift in Sources */,
+				218C79B2F2245C5838FA75AC5B0A2BF2 /* ColorSchemeManager.swift in Sources */,
+				59533624A21B64CDA632B66A0B2F315E /* InnerShadowModifier.swift in Sources */,
+				B70903068440C89B3FB10BA61A877B18 /* LinearGradient+Extension.swift in Sources */,
+				B888011D97B2A573C872D4E59454F2B8 /* NMButtonStyle.swift in Sources */,
+				97EAF528B73D1D65509641E11A64DAE8 /* NMToggleStyle.swift in Sources */,
+				21D29DC737DF1191595717C25FB3DF23 /* OuterShadowModifier.swift in Sources */,
+				F4D665B02CFAC4FEC765FC980756BE5F /* SSNeumorphicButton.swift in Sources */,
+				57B678D261608678F9619E2D09BFB615 /* SSNeumorphicLayer.swift in Sources */,
+				4043948E4ED5CB7B912654301993EA0F /* SSNeumorphicTextField.swift in Sources */,
+				AEFC372DE44B681C7351516806431E56 /* SSNeumorphicView.swift in Sources */,
+				6EB3D0FA230B888A312D955DF1A8983E /* SSNeumorphicView-dummy.m in Sources */,
+				8F8F0BA818BD9EFBB58C1E771B519B0D /* View+Extension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -480,17 +480,17 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		0F77C200AD321FC4B940A9BC1867C99F /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = SSNeumorphicView;
-			target = DAAB6534CA573FAE41802F72CCE1277E /* SSNeumorphicView */;
-			targetProxy = 392CEA713654F90366DB9B3F916E46C8 /* PBXContainerItemProxy */;
-		};
-		E6FB695242191C2F34EB1BFE3F0EC653 /* PBXTargetDependency */ = {
+		150A51EBC69BB7E7F03737A955BCF7F0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-SSNeumorphicView_Example";
 			target = 9A4BF4BE08D3D15C28A262F12B1415B3 /* Pods-SSNeumorphicView_Example */;
-			targetProxy = 25A812372BB05B66F202F33B64EA1C1F /* PBXContainerItemProxy */;
+			targetProxy = 6D8F836AE703BDCB6D05E357C3BA4439 /* PBXContainerItemProxy */;
+		};
+		4E8B539F1C56EA5C2F2FE3DC702CFEC6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SSNeumorphicView;
+			target = DAAB6534CA573FAE41802F72CCE1277E /* SSNeumorphicView */;
+			targetProxy = 47CBBF93FC79A79E2F791EA5F32E4B4F /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -563,6 +563,39 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
+		};
+		2E7DD5E4193AB3F38FD77EDCC7D94F0F /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = DF37CFFF3D237F48F89953E68DCC13E5 /* SSNeumorphicView.release.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/SSNeumorphicView/SSNeumorphicView-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/SSNeumorphicView/SSNeumorphicView-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/SSNeumorphicView/SSNeumorphicView.modulemap";
+				PRODUCT_MODULE_NAME = SSNeumorphicView;
+				PRODUCT_NAME = SSNeumorphicView;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
 		};
 		8DE5143C03248BB6CD542DE3963D6F3A /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -691,39 +724,6 @@
 			};
 			name = Release;
 		};
-		CDDAF26A8E88A80794C3319F0593A89B /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = DF37CFFF3D237F48F89953E68DCC13E5 /* SSNeumorphicView.release.xcconfig */;
-			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/SSNeumorphicView/SSNeumorphicView-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/SSNeumorphicView/SSNeumorphicView-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/SSNeumorphicView/SSNeumorphicView.modulemap";
-				PRODUCT_MODULE_NAME = SSNeumorphicView;
-				PRODUCT_NAME = SSNeumorphicView;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 6.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
 		CE59B5DC03DA59AB067D5E58E43A9218 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 63F44A008894F053192326ECE5DB9652 /* Pods-SSNeumorphicView_Tests.debug.xcconfig */;
@@ -758,7 +758,7 @@
 			};
 			name = Debug;
 		};
-		EB5914567B68855C646F28E24543470A /* Debug */ = {
+		F5C0B9CE5DC88222C6EFB54575854CFF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7C73668DD75EA4DA395E8B3F98DA90CC /* SSNeumorphicView.debug.xcconfig */;
 			buildSettings = {
@@ -828,20 +828,20 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		400C8C38773D22E7471520C199DD66B5 /* Build configuration list for PBXNativeTarget "SSNeumorphicView" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F5C0B9CE5DC88222C6EFB54575854CFF /* Debug */,
+				2E7DD5E4193AB3F38FD77EDCC7D94F0F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		4821239608C13582E20E6DA73FD5F1F9 /* Build configuration list for PBXProject "Pods" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				8DE5143C03248BB6CD542DE3963D6F3A /* Debug */,
 				9E406C6AAF85E580207CD97B0044DEAB /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		A6BE21B9D9F9993D1DE0BBF70C879F20 /* Build configuration list for PBXNativeTarget "SSNeumorphicView" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				EB5914567B68855C646F28E24543470A /* Debug */,
-				CDDAF26A8E88A80794C3319F0593A89B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Example/SSNeumorphicView/Base.lproj/Main.storyboard
+++ b/Example/SSNeumorphicView/Base.lproj/Main.storyboard
@@ -70,7 +70,7 @@
                                 </userDefinedRuntimeAttributes>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="beK-oF-TsR" customClass="SSNeumorphicButton" customModule="SSNeumorphicView">
-                                <rect key="frame" x="20" y="699" width="374" height="60"/>
+                                <rect key="frame" x="20" y="598" width="374" height="60"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="60" id="TAF-e1-aC1"/>
                                 </constraints>
@@ -94,7 +94,7 @@
                             <constraint firstItem="bgT-RM-H8s" firstAttribute="centerX" secondItem="ikR-pH-dZt" secondAttribute="centerX" id="K1L-sB-qEy"/>
                             <constraint firstItem="dm0-uf-rKT" firstAttribute="top" secondItem="jry-b9-aQa" secondAttribute="bottom" constant="40" id="MFA-YE-9N9"/>
                             <constraint firstItem="dm0-uf-rKT" firstAttribute="leading" secondItem="Vox-rQ-XB8" secondAttribute="leading" constant="20" id="ORF-Sj-Ki3"/>
-                            <constraint firstItem="beK-oF-TsR" firstAttribute="top" secondItem="bgT-RM-H8s" secondAttribute="bottom" constant="161" id="R2c-TK-TDn"/>
+                            <constraint firstItem="beK-oF-TsR" firstAttribute="top" secondItem="bgT-RM-H8s" secondAttribute="bottom" constant="60" id="R2c-TK-TDn"/>
                             <constraint firstItem="Vox-rQ-XB8" firstAttribute="trailing" secondItem="dm0-uf-rKT" secondAttribute="trailing" constant="20" id="XNU-me-Wrg"/>
                             <constraint firstItem="beK-oF-TsR" firstAttribute="leading" secondItem="dm0-uf-rKT" secondAttribute="leading" id="gC2-aq-pm8"/>
                             <constraint firstItem="beK-oF-TsR" firstAttribute="trailing" secondItem="dm0-uf-rKT" secondAttribute="trailing" id="mtB-mN-vzG"/>

--- a/Example/SSNeumorphicView/SwiftUI/ContentView.swift
+++ b/Example/SSNeumorphicView/SwiftUI/ContentView.swift
@@ -115,7 +115,9 @@ struct ContentView: View {
                                 )
                         }
                         Button("Coloured Demo") {
-                            changeColor()
+                            withAnimation {
+                                changeColor()
+                            }
                         }
                         .buttonStyle(NMButtonStyle(shape: RoundedRectangle(cornerRadius: 5),
                                                     padding: 20,

--- a/Example/SSNeumorphicView/SwiftUI/ContentView.swift
+++ b/Example/SSNeumorphicView/SwiftUI/ContentView.swift
@@ -15,81 +15,132 @@ struct ContentView: View {
     
     @State var text = ""
     @State var isOn = false
+    @State var mainColor = Color.Neumorphic.main
+    @State var darkShadow = Color.Neumorphic.darkShadow
+    @State var lightShadow = Color.Neumorphic.lightShadow
+    
+    private let purple = Color(red: 0.749, green: 0.675, blue: 0.992)
+    private let purpleLightVarient = Color(red: 0.823, green: 0.773, blue: 0.996)
+    private let purpleDarkVarient = Color(red: 0.224, green: 0.204, blue: 0.298)
     
     // MARK: - Body
     
     var body: some View {
         
-        ZStack {
-            
-            Color.Neumorphic.main
-            
-            VStack(spacing: 30) {
+            ZStack {
                 
-                HStack(spacing: 50) {
-                    RoundedRectangle(cornerRadius: 25)
-                        .fill(Color.Neumorphic.main)
-                        .frame(width: 150, height: 150)
-                        .innerShadow(RoundedRectangle(cornerRadius: 25))
-                    RoundedRectangle(cornerRadius: 25)
-                        .fill(Color.Neumorphic.main)
-                        .frame(width: 150, height: 150)
-                        .outerShadow()
-                }
+                mainColor
                 
-                HStack(spacing: 50) {
-                    Circle()
-                        .fill(Color.Neumorphic.main)
-                        .frame(width: 150, height: 150)
-                        .innerShadow(Circle())
-                    Circle()
-                        .fill(Color.Neumorphic.main)
-                        .frame(width: 150, height: 150)
-                        .outerShadow()
-                }
-                
-                HStack(spacing: 50) {
-                    Button(action: {
-                        print("Button tapped")
-                    }) {
-                        Text("Tap me!")
-                    }
-                    .buttonStyle(NMButtonStyle(shape: RoundedRectangle(cornerRadius: 20)))
+                ScrollView {
                     
-                    Button(action: {
-                        print("Button tapped")
-                    }) {
-                        Image(systemName: "heart.fill").font(.system(size: 30))
+                    VStack(spacing: 30) {
+                        Spacer().frame(height: 65)
+                        HStack(spacing: 50) {
+                            RoundedRectangle(cornerRadius: 25)
+                                .fill(mainColor)
+                                .frame(width: 150, height: 150)
+                                .innerShadow(RoundedRectangle(cornerRadius: 25),
+                                             darkShadow: darkShadow,
+                                             lightShadow: lightShadow)
+                            RoundedRectangle(cornerRadius: 25)
+                                .fill(mainColor)
+                                .frame(width: 150, height: 150)
+                                .outerShadow(darkShadow: darkShadow,
+                                             lightShadow: lightShadow)
+                        }
+                        
+                        HStack(spacing: 50) {
+                            Circle()
+                                .fill(mainColor)
+                                .frame(width: 150, height: 150)
+                                .innerShadow(Circle(),
+                                             darkShadow: darkShadow,
+                                             lightShadow: lightShadow)
+                            Circle()
+                                .fill(mainColor)
+                                .frame(width: 150, height: 150)
+                                .outerShadow(darkShadow: darkShadow,
+                                             lightShadow: lightShadow)
+                        }
+                        
+                        HStack(spacing: 50) {
+                            Button(action: {
+                                print("Button tapped")
+                            }) {
+                                Text("Tap me!")
+                            }
+                            .buttonStyle(NMButtonStyle(shape: RoundedRectangle(cornerRadius: 20),
+                                                       primaryColor: mainColor,
+                                                       lightColor: lightShadow,
+                                                       darkColor: darkShadow))
+                            
+                            Button(action: {
+                                print("Button tapped")
+                            }) {
+                                Image(systemName: "heart.fill").font(.system(size: 30))
+                            }
+                            .buttonStyle(NMButtonStyle(shape: Circle(),
+                                                       primaryColor: mainColor,
+                                                       lightColor: lightShadow,
+                                                       darkColor: darkShadow))
+                        }
+                        
+                        TextField("Enter text", text: $text)
+                            .padding()
+                            .background(RoundedRectangle(cornerRadius: 30)
+                                .fill(mainColor)
+                                .innerShadow(RoundedRectangle(cornerRadius: 30),
+                                             darkShadow: darkShadow,
+                                             lightShadow: lightShadow), alignment: .center)
+                            .padding()
+                        if #available(iOS 14.0, *) {
+                            Toggle("Toggle: ", isOn: $isOn)
+                                .toggleStyle(
+                                    NMToggleStyle(
+                                        tintColor: .green,
+                                        offTintColor: mainColor,
+                                        offDarkShadow: darkShadow,
+                                        offLightShadow: lightShadow,
+                                        hideLabel: false
+                                    )
+                                )
+                                .padding()
+                        } else {
+                            Toggle("Toggle: ", isOn: $isOn)
+                                .toggleStyle(
+                                    NMToggleStyle(
+                                        tintColor: .red,
+                                        hideLabel: false
+                                    )
+                                )
+                        }
+                        Button("Coloured Demo") {
+                            changeColor()
+                        }
+                        .buttonStyle(NMButtonStyle(shape: RoundedRectangle(cornerRadius: 5),
+                                                    padding: 20,
+                                                    primaryColor: mainColor,
+                                                    lightColor: lightShadow,
+                                                    darkColor: darkShadow))
+                        Spacer().frame(height: 30)
                     }
-                    .buttonStyle(NMButtonStyle(shape: Circle()))
-                }
-                
-                TextField("Enter text", text: $text)
-                    .padding()
-                    .background(RoundedRectangle(cornerRadius: 30)
-                        .fill(Color.Neumorphic.main)
-                        .innerShadow(RoundedRectangle(cornerRadius: 30)), alignment: .center)
-                    .padding()
-                if #available(iOS 14.0, *) {
-                    Toggle("Toggle: ", isOn: $isOn)
-                        .toggleStyle(
-                            NMToggleStyle(
-                                tintColor: .green,
-                                hideLabel: false
-                            )
-                        )
-                        .padding()
-                } else {
-                    Toggle("Toggle: ", isOn: $isOn)
-                        .toggleStyle(
-                            NMToggleStyle(
-                                tintColor: .red,
-                                hideLabel: false
-                            )
-                        )
                 }
             }
+            .edgesIgnoringSafeArea(.all)
+    }
+    
+    // MARK: - Functions
+    
+    /// Toggles between default neumorphic theme and Colored NeumorphicTheme
+    private func changeColor() {
+        if(mainColor == purple) {
+            mainColor = Color.Neumorphic.main
+            darkShadow = Color.Neumorphic.darkShadow
+            lightShadow = Color.Neumorphic.lightShadow
+        } else {
+            mainColor = purple
+            darkShadow = purpleDarkVarient
+            lightShadow = purpleLightVarient
         }
-        .edgesIgnoringSafeArea(.all)
     }
 }

--- a/Sources/SSNeumorphicView/Classes/SwiftUI/Helpers/Extensions/View+Extension.swift
+++ b/Sources/SSNeumorphicView/Classes/SwiftUI/Helpers/Extensions/View+Extension.swift
@@ -15,18 +15,21 @@ extension View {
     ///   - lightShadow: The color of the light shadow for the bottom trailing area (default is `Color.Neumorphic.lightShadow`).
     ///   - offset: The offset of the shadows. This offset will be applied to both shadows (default is `2`).
     ///   - radius: The blur radius for the shadows. A lower radius gives a sharper shadow, while a higher radius provides a smoother shadow (default is `2`).
+    ///   - shadowWidth: The width of the inner shadow (default is `8`).
     /// - Returns: A view with the applied inner shadow effect.
     public func innerShadow<S: Shape>(
         _ shape: S,
         darkShadow: Color = Color.Neumorphic.darkShadow,
         lightShadow: Color = Color.Neumorphic.lightShadow,
         offset: CGFloat = 2,
-        radius: CGFloat = 2
+        radius: CGFloat = 2,
+        shadowWidth: CGFloat = 8
     ) -> some View {
         modifier(InnerShadowModifier(shape: shape,
                                      shadowColorDark: darkShadow,
                                      shadowColorLight: lightShadow,
                                      radius: radius,
+                                     shadowWidth: shadowWidth,
                                      offset: offset))
     }
     

--- a/Sources/SSNeumorphicView/Classes/SwiftUI/Modifiers/InnerShadowModifier.swift
+++ b/Sources/SSNeumorphicView/Classes/SwiftUI/Modifiers/InnerShadowModifier.swift
@@ -38,14 +38,14 @@ public struct InnerShadowModifier<S: Shape>: ViewModifier {
     ///   - shadowColorDark: The color of the dark shadow (default is `Color.Neumorphic.darkShadow`).
     ///   - shadowColorLight: The color of the light shadow (default is `Color.Neumorphic.lightShadow`).
     ///   - radius: The blur radius of the shadow.
-    ///   - shadowWidth: The width of the shadow (default is `8`).
-    ///   - offset: The offset of the shadow (default is `2`).
+    ///   - shadowWidth: The width of the shadow.
+    ///   - offset: The offset of the shadow.
     public init(shape: S,
                 shadowColorDark: Color = Color.Neumorphic.darkShadow,
                 shadowColorLight: Color = Color.Neumorphic.lightShadow,
                 radius: CGFloat,
-                shadowWidth: CGFloat = 8,
-                offset: CGFloat = 2) {
+                shadowWidth: CGFloat,
+                offset: CGFloat) {
         self.shadowColorDark = shadowColorDark
         self.shadowColorLight = shadowColorLight
         self.radius = radius

--- a/Sources/SSNeumorphicView/Classes/SwiftUI/Styles/NMButtonStyle.swift
+++ b/Sources/SSNeumorphicView/Classes/SwiftUI/Styles/NMButtonStyle.swift
@@ -26,6 +26,24 @@ public struct NMButtonStyle<S: Shape>: ButtonStyle {
     /// The color of the light shadow.
     var lightColor: Color
     
+    /// The offset of the inner shadow from the button's content.
+    var innerShadowOffset: CGFloat
+    
+    /// The blur radius for the button's inner shadow.
+    var innerShadowBlurRadius: CGFloat
+    
+    /// The offset of the light shadow from the button's background.
+    var outerLightShadowOffset: CGFloat
+    
+    /// The offset of the dark shadow from the button's background.
+    var outerDarkShadowOffset: CGFloat
+    
+    /// The blur radius for the button's outer shadows.
+    var outerShadowRadius: CGFloat
+    
+    /// The width of the inner shadows.
+    var innerShadowWidth: CGFloat
+    
     // MARK: - Initializers
     
     /// Creates an `NMButtonStyle` with specified parameters.
@@ -35,16 +53,35 @@ public struct NMButtonStyle<S: Shape>: ButtonStyle {
     ///   - primaryColor: The primary color of the button (default is `Color.Neumorphic.main`).
     ///   - lightColor: The color of the light shadow (default is `Color.Neumorphic.lightShadow`).
     ///   - darkColor: The color of the dark shadow (default is `Color.Neumorphic.darkShadow`).
+    ///   - innerShadowOffset: The offset of the inner shadow from the button's content (default is `2`).
+    ///   - innerShadowBlurRadius: The blur radius for the button's inner shadow (default is `2`).
+    ///   - innerShadowWidth: The width of the inner shadow (default is `8`).
+    ///   - outerLightShadowOffset: The offset of the light shadow from the button's background (default is `3`).
+    ///   - outerDarkShadowOffset: The offset of the dark shadow from the button's background (default is `5`).
+    ///   - outerShadowRadius: The blur radius for the button's outer shadows (default is `4`).
     public init(shape: S,
                 padding: CGFloat = 30,
                 primaryColor: Color = Color.Neumorphic.main,
                 lightColor: Color = Color.Neumorphic.lightShadow,
-                darkColor: Color = Color.Neumorphic.darkShadow) {
+                darkColor: Color = Color.Neumorphic.darkShadow,
+                innerShadowOffset: CGFloat = 2,
+                innerShadowBlurRadius: CGFloat = 2,
+                innerShadowWidth: CGFloat = 8,
+                outerLightShadowOffset: CGFloat = 3,
+                outerDarkShadowOffset: CGFloat = 5,
+                outerShadowRadius: CGFloat = 4
+    ) {
         self.shape = shape
         self.padding = padding
         self.darkColor = darkColor
         self.lightColor = lightColor
         self.primaryColor = primaryColor
+        self.outerLightShadowOffset = outerLightShadowOffset
+        self.outerDarkShadowOffset = outerDarkShadowOffset
+        self.outerShadowRadius = outerShadowRadius
+        self.innerShadowOffset = innerShadowOffset
+        self.innerShadowBlurRadius = innerShadowBlurRadius
+        self.innerShadowWidth = innerShadowWidth
     }
     
     // MARK: - ButtonStyle Body
@@ -61,16 +98,21 @@ public struct NMButtonStyle<S: Shape>: ButtonStyle {
                     if configuration.isPressed {
                         shape
                             .fill(primaryColor)
-                            .innerShadow(shape, darkShadow: darkColor, lightShadow: lightColor)
+                            .innerShadow(shape,
+                                         darkShadow: darkColor,
+                                         lightShadow: lightColor,
+                                         offset: innerShadowOffset,
+                                         radius: innerShadowBlurRadius,
+                                         shadowWidth: innerShadowWidth)
                     } else {
                         // For outer shadow
                         shape
                             .fill(primaryColor)
                             .outerShadow(darkShadow: darkColor,
                                          lightShadow: lightColor,
-                                         lightShadowOffset: 5,
-                                         darkShadowOffset: 8,
-                                         radius: 4)
+                                         lightShadowOffset: outerLightShadowOffset,
+                                         darkShadowOffset: outerDarkShadowOffset,
+                                         radius: outerShadowRadius)
                     }
                 }
             )

--- a/Sources/SSNeumorphicView/Classes/SwiftUI/Styles/NMToggleStyle.swift
+++ b/Sources/SSNeumorphicView/Classes/SwiftUI/Styles/NMToggleStyle.swift
@@ -189,7 +189,7 @@ public struct NMToggleStyle: ToggleStyle {
                     // Shape that makes the outside of the toggle.
                     Capsule()
                         .fill(offTintColor)
-                        .outerShadow()  // Give outer shadows for the outer shape.
+                        .outerShadow(darkShadow: offDarkShadow, lightShadow: offLightShadow)  // Give outer shadows for the outer shape.
                         .frame(width: width, height: height)
                     
                     // Shape that makes the inside of the toggle.


### PR DESCRIPTION
- Add Coloured NeumorphicView demo screen
- Make demo screen scrollable by wrapping it in ScrollView.
- Decrease the spacing between **"Go to SwiftUI Demo"** button and **"heart"** button in `Main.storyboard`.
- Add inner shadow width parameter in **innerShadow** extension for View.
- Remove default values from **InnerShadowModifier** code.
- Added customization options for inner shadow offset, blur radius, width, and outer shadow settings for improved neumorphic styling.
- Added **offDarkShadow** and **offLightShadow** Colours in `NMToggleStyle.swift`.